### PR TITLE
Fix optional style include from Building Block configuration.

### DIFF
--- a/src/main/webapp/upcoming-events.jsp
+++ b/src/main/webapp/upcoming-events.jsp
@@ -76,9 +76,12 @@
 %>
 
 <%@ include file="upcoming-events-css.jsp" %>
+
+<c:if test="${not empty configuration.customCss}">
 <style>
-<%= configuration.getCustomCss() %>
+    <c:out escapeXml="false" value="${configuration.customCss}" />
 </style>
+</c:if>
 
 <fmt:setLocale value="${ctx.locale}" />
 <fmt:setBundle basename="BlackboardMessagesBundle" />


### PR DESCRIPTION
When not set, <style>null</style> was added to the page output.